### PR TITLE
Avoid breaking the loop if a table is not found

### DIFF
--- a/vpinfe.py
+++ b/vpinfe.py
@@ -346,6 +346,7 @@ def buildMetaData():
                 vpsData = vps.lookupName(vpsSearchData["name"], vpsSearchData["manufacturer"], vpsSearchData["year"])
             except TypeError as e:
                 logger.error(f"{RED_CONSOLE_TEXT}Not found in VPS{RESET_CONSOLE_TEXT}")
+                continue
             
             # vpx file info
             logger.info(f"Parsing VPX file for metadata")


### PR DESCRIPTION
In case of a table is not found the program is aborting the execution immediately. 

`2025-05-19 17:05:51,620 - VPinFE - ERROR - Not found in VPS
2025-05-19 17:05:51,620 - VPinFE - INFO - Parsing VPX file for metadata
2025-05-19 17:05:51,620 - VPinFE - INFO - Extracting /Users/herrmirto/pinballtables/24 Stern (2009)/24 (Stern 2009) VPX08 (DT-FS-FSS-VR) v.2.1.vpx for metadata.
Traceback (most recent call last):
  File "/Users/andremichi/vpinfe/vpinfe.py", line 556, in <module>
    parseArgs()
  File "/Users/andremichi/vpinfe/vpinfe.py", line 391, in parseArgs
    buildMetaData()
  File "/Users/andremichi/vpinfe/vpinfe.py", line 356, in buildMetaData
    finalini['vpsdata'] = vpsData
                          ^^^^^^^
UnboundLocalError: cannot access local variable 'vpsData' where it is not associated with a value
`

Not sure if this is intentional or not. But with this change the program continues the execution:

`2025-05-19 17:07:37,226 - VPinFE - INFO - Checking VPSdb for James Cameron's Avatar Stern (2010)
2025-05-19 17:07:37,226 - VPinFE - ERROR - Not found in VPS
2025-05-19 17:07:37,227 - VPinFE - INFO - Checking VPSdb for Nags Williams (1960)
2025-05-19 17:07:37,227 - VPinFE - ERROR - Not found in VPS
2025-05-19 17:07:37,227 - VPinFE - INFO - Checking VPSdb for Scramble Tecnoplay (1987)
2025-05-19 17:07:37,227 - VPinFE - ERROR - Not found in VPS
2025-05-19 17:07:37,227 - VPinFE - INFO - Checking VPSdb for Sublime (Original 2025)
2025-05-19 17:07:37,261 - VPinFE - INFO - Name, manufacturer, and year matched with threshold: Sublime
2025-05-19 17:07:37,261 - VPinFE - INFO - Parsing VPX file for metadata
`